### PR TITLE
Move registration of formatter to configure time

### DIFF
--- a/lib/simplecov/inline/integration.rb
+++ b/lib/simplecov/inline/integration.rb
@@ -3,6 +3,8 @@ module SimpleCov
     class Integration
       class << self
         def configure_rspec_rails(rspec: RSpec, rails: Rails)
+          RSpec::Core::Formatters.register SimpleCov::Inline::RSpecFormatterSkipOnFailure, :dump_failures
+
           rspec.configure do |rspec_config|
             rspec_config.add_formatter SimpleCov::Inline::RSpecFormatterSkipOnFailure
             rspec_config.before(:suite) do

--- a/lib/simplecov/inline/rspec_formatter_skip_on_failure.rb
+++ b/lib/simplecov/inline/rspec_formatter_skip_on_failure.rb
@@ -1,8 +1,6 @@
 module SimpleCov
   module Inline
     class RSpecFormatterSkipOnFailure
-      RSpec::Core::Formatters.register self, :dump_failures
-
       def initialize(output)
         @output = output
       end

--- a/spec/lib/simplecov/inline/integration_spec.rb
+++ b/spec/lib/simplecov/inline/integration_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe SimpleCov::Inline::Integration do
       allow(rspec_config).to receive(:add_formatter)
       allow(rspec_config).to receive(:before)
       allow(described_class).to receive(:configure_formatter)
+      allow(RSpec::Core::Formatters).to receive(:register)
+    end
+
+    it 'registers the rspec formatter' do
+      subject
+
+      expect(RSpec::Core::Formatters)
+        .to have_received(:register)
+        .with(SimpleCov::Inline::RSpecFormatterSkipOnFailure, :dump_failures)
     end
 
     it 'adds a formatter to the rspec config', :aggregate_failures do


### PR DESCRIPTION
Formatter is being registered at load time, which causes errors now that this
code is in a gem.

Move the registration to the rspec configuration class.